### PR TITLE
Error message from Jobs module in Pybossa

### DIFF
--- a/pybossa/jobs.py
+++ b/pybossa/jobs.py
@@ -742,9 +742,10 @@ def news():
         urls += current_app.config.get('NEWS_URL')
     for url in urls:
         d = feedparser.parse(url)
+        entries = d.entries if d and d.entries else None
         tmp = get_news(score)
         if (d.entries and (len(tmp) == 0)
-           or (tmp[0]['updated'] != d.entries[0]['updated'])):
+           or (tmp and entries and tmp[0]['updated'] != entries[0]['updated'])):
             mapping = dict()
             mapping[pickle.dumps(d.entries[0])] = float(score)
             sentinel.master.zadd(FEED_KEY, mapping)


### PR DESCRIPTION
This fix is added in order to get rid of errors which are sent to emails.
Example of error:
Traceback (most recent call last):
 File "/usr/local/lib/python3.8/site-packages/rq/worker.py", line 799, in perform_job
   rv = job.perform()
 File "/usr/local/lib/python3.8/site-packages/rq/job.py", line 600, in perform
   self._result = self._execute()
 File "/usr/local/lib/python3.8/site-packages/rq/job.py", line 606, in _execute
   return self.func(*self.args, **self.kwargs)
 File "/opt/pybossa/pybossa/jobs.py", line 747, in news
   or (tmp[0]['updated'] != d.entries[0]['updated'])):
IndexError: list index out of range
 
